### PR TITLE
fix typo in GeoCoordinatesGoogleFormatType

### DIFF
--- a/OICP-2.3/OICP 2.3 EMP/03_EMP_Data_Types.asciidoc
+++ b/OICP-2.3/OICP 2.3 EMP/03_EMP_Data_Types.asciidoc
@@ -70,7 +70,7 @@ DegreeMinuteSeconds:<<GeoCoordinatesDegreeMinuteSecondsType,GeoCoordinatesDegree
 [%header,format=dsv, cols=4]
 |=====================
 Name:Data Type:Description:M/O
-Coordinatea: <<GeoCoordinatesGoogleFormatType,GeoCoordinatesGoogleFormatType>>:Based on WGS84: M
+Coordinates: <<GeoCoordinatesGoogleFormatType,GeoCoordinatesGoogleFormatType>>:Based on WGS84: M
 |=====================
 
 [[GeoCoordinatesDecimalDegreeType]]


### PR DESCRIPTION
fixes a typo in documentation
