### PR TITLE
Removed "calibrationLawDataAvailability" from ERoamingPullEvseData

### DIFF
--- a/OICP-2.3/SWAGGER DOCUMENTATION/evse-api-docs-2.3.json
+++ b/OICP-2.3/SWAGGER DOCUMENTATION/evse-api-docs-2.3.json
@@ -812,17 +812,6 @@
         "SearchCenter": {
           "description": "The data can be restricted using search parameters that are provided in this field. Cannot be combined with LastCall.",
           "$ref": "#/definitions/SearchCenter"
-        },
-        "calibrationLawDataAvailability": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "Local",
-              "External",
-              "Not Available"
-            ]
-          }
         }
       },
       "description": "ERoamingPullEvseData model"


### PR DESCRIPTION
There already is a field called `CalibrationLawDataAvailability` so there is no need for `calibrationLawDataAvailability`