### PR TITLE
OICP 2.3 Final Release

### DIFF
--- a/OICP-2.3/SWAGGER DOCUMENTATION/evse-api-docs-2.3.json
+++ b/OICP-2.3/SWAGGER DOCUMENTATION/evse-api-docs-2.3.json
@@ -810,17 +810,6 @@
         "SearchCenter": {
           "description": "The data can be restricted using search parameters that are provided in this field. Cannot be combined with LastCall.",
           "$ref": "#/definitions/SearchCenter"
-        },
-        "calibrationLawDataAvailability": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "enum": [
-              "Local",
-              "External",
-              "Not Available"
-            ]
-          }
         }
       },
       "description": "ERoamingPullEvseData model"
@@ -1760,9 +1749,6 @@
             "Saturday",
             "Sunday"
           ]
-        },
-        "unstructuredOpeningTime": {
-          "type": "string"
         }
       },
       "description": "OpeningTime model"


### PR DESCRIPTION
Delete "UnstructuredOpeningtimes" field and doubled "calibrationLaw.."