### PR TITLE
Bugfix: ChargingStationID instead of ChargingStationId

### DIFF
--- a/OICP-2.3/OICP 2.3 EMP/03_EMP_Data_Types.asciidoc
+++ b/OICP-2.3/OICP 2.3 EMP/03_EMP_Data_Types.asciidoc
@@ -199,7 +199,7 @@ deltaType:`update` or `insert` or `delete`:In case that the operation “PullEvs
 lastUpdate:Date/Time:The attribute indicates the date and time of the last update of the record. Hubject assigns this attribute to every response EVSE record.:O:
 EvseID:<<EvseIDType,EvseIDType>>:The ID that identifies the charging spot.:M:
 ChargingPoolID:<<ChargingPoolIDType,ChargingPoolIDType>>:The ID that identifies the charging station.:O:
-ChargingStationId:String:The ID that identifies the charging station.:O:50
+ChargingStationID:String:The ID that identifies the charging station.:O:50
 ChargingStationNames:List <<InfoTextType,InfoTextType>>:Name of the charging station:M:
 HardwareManufacturer:String:Name of the charging point manufacturer:O:50
 ChargingStationImage:String:URL that redirect to an online image of the related EVSEID:O:200


### PR DESCRIPTION
The actual API returns the object with a key of `ChargingStationID`, not `ChargingStationId`.