### PR TITLE
OICP 2.3 Final Release

### DIFF
--- a/OICP-2.3/OICP 2.3 CPO/03_CPO_Data_Types.asciidoc
+++ b/OICP-2.3/OICP 2.3 CPO/03_CPO_Data_Types.asciidoc
@@ -447,7 +447,11 @@ SignedMeteringValue `SHOULD` be always sent in following order
 |MeteringStatus|<<MeteringStatusType,MeteringStatusType>>|The status type of the metering signature provided (e.g. Start, Progress, End)|O|
 |=====
 
-NOTE: The MeteringSignatureValue format provided `MUST` be supported by the Transparency Software used by the CPO
+[NOTE]
+====
+.This field 'MUST' be provided when the EVSEID contains the "External" value in the CalibrationLawDataAvailability field.
+.The MeteringSignatureValue format provided `MUST` be supported by the Transparency Software used by the CPO
+====
 
 [[CalibrationLawVerificationType]]
 === CalibrationLawVerificationType


### PR DESCRIPTION
Adding explanation to logic between SignedMeteringValuesType in the CDR with the CalibrationLawDataAvailabilityType in the EVSEID data