### PR TITLE
Fix ErrorClassType spelling of enums

### DIFF
--- a/OICP-2.3/OICP 2.3 EMP/03_EMP_Data_Types.asciidoc
+++ b/OICP-2.3/OICP 2.3 EMP/03_EMP_Data_Types.asciidoc
@@ -784,8 +784,8 @@ End	:	Metering Signature Value of the end of the charging process.
 [%header]
 |===
 |Option|Description
-|Connector Error|Charging process cannot be started or stopped. EV driver needs to check if the the Plug is properly inserted or taken out from socket.
-|Critical Error| Charging process stopped abruptly.
+|ConnectorError|Charging process cannot be started or stopped. EV driver needs to check if the the Plug is properly inserted or taken out from socket.
+|CriticalError| Charging process stopped abruptly.
 Reason: Physical check at the station is required. Station cannot be reset online.
 
 Or


### PR DESCRIPTION
As per the following error message from the API, the enum spelling is wrong:
```json
{
    "message": "Error validating/mapping JSON.",
    "validationErrors": [
        {
            "fieldReference": "ErrorType",
            "errorMessage": "Error mapping field: Cannot deserialize value of type `com.hubject.hbs2.notification.model.charging.ErrorType` from String \"Critical Error\": not one of the values accepted for Enum class: [CriticalError, ConnectorError]\n at [Source: (PushbackInputStream); line: 11, column: 18] (through reference chain: com.hubject.hbs2.notification.model.charging.ChargingErrorNotification[\"ErrorType\"])"
        }
    ]
}
```

**Note:** I've not tested the CPO API yet, hence it is not fixed by this PR. Please check the CPO part as well when merging this PR.