### PR TITLE
Fix physical unit typo

### DIFF
--- a/OICP-2.2/SWAGGER DOCUMENTATION/dynamic-pricing-api-docs-1.0.json
+++ b/OICP-2.2/SWAGGER DOCUMENTATION/dynamic-pricing-api-docs-1.0.json
@@ -886,7 +886,7 @@
         },
         "MaximumProductChargingPower": {
           "type": "number",
-          "description": "A value in kWh"
+          "description": "A value in kW"
         },
         "PricePerReferenceUnit": {
           "type": "number",

--- a/OICP-2.3/OICP 2.3 CPO/03_CPO_Data_Types.asciidoc
+++ b/OICP-2.3/OICP 2.3 CPO/03_CPO_Data_Types.asciidoc
@@ -307,7 +307,7 @@ ProductID:<<ProductIDType,ProductIDType>>:A pricing product name (for identifyin
 ReferenceUnit:<<ReferenceUnitType,ReferenceUnitType>>:Reference unit in time or kWh:M:
 ProductPriceCurrency:<<CurrencyIDType,CurrencyIDType>>:Currency for default prices:M:
 PricePerReferenceUnit:Decimal:A price per reference unit:M:
-MaximumProductChargingPower:Decimal:A value in kWh:M:
+MaximumProductChargingPower:Decimal:A value in kW:M:
 IsValid24hours:Boolean:Set to TRUE if the respective pricing product is applicable 24 hours a day. If FALSE, the respective applicability times `SHOULD` be provided in the field “ProductAvailabilityTimes”.:M:
 ProductAvailabilityTimes:<<ProductAvailabilityTimesType,ProductAvailabilityTimesType>>:A list indicating when the pricing product is applicable:M:
 AdditionalReferences:<<AdditionalReferencesType,AdditionalReferencesType>>:A list of additional reference units and their respective prices:O:0...n

--- a/OICP-2.3/OICP 2.3 EMP/03_EMP_Data_Types.asciidoc
+++ b/OICP-2.3/OICP 2.3 EMP/03_EMP_Data_Types.asciidoc
@@ -310,7 +310,7 @@ ProductID:<<ProductIDType,ProductIDType>>:A pricing product name (for identifyin
 ReferenceUnit:<<ReferenceUnitType,ReferenceUnitType>>:Reference unit in time or kWh:M:
 ProductPriceCurrency:<<CurrencyIDType,CurrencyIDType>>:Currency for default prices:M:
 PricePerReferenceUnit:Decimal:A price per reference unit:M:
-MaximumProductChargingPower:Decimal:A value in kWh:M:
+MaximumProductChargingPower:Decimal:A value in kW:M:
 IsValid24hours:Boolean:Set to TRUE if the respective pricing product is applicable 24 hours a day. If FALSE, the respective applicability times should be provided in the field “ProductAvailabilityTimes”.:M:
 ProductAvailabilityTimes:<<ProductAvailabilityTimesType,ProductAvailabilityTimesType>>:A list indicating when the pricing product is applicable:M:
 AdditionalReferences:<<AdditionalReferencesType,AdditionalReferencesType>>:A list of additional reference units and their respective prices:O:0...n


### PR DESCRIPTION
The protocol wrongly claims that `MaximumProductChargingPower` is measured in kilowatt-hours, but [physics dictates that that is a unit of energy](https://en.wikipedia.org/wiki/Kilowatt-hour) and power is measured rather in kilowatts, i.e. `kW`. Fixing this typo.