### PR TITLE
Remove OICP 2.1 https link & public message

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,18 @@
 
 Here you can find all documents and information about the open source OICP .
 
-The OICP protocol, created in 2012, now connects more than 1000 companies in 43 countries in order to make EV charging easy and seamless for everyone.
+The OICP protocol, created in 2012, now connects more than 1000 companies in 52 countries in order to make EV charging easy and seamless for everyone.
 
 ## Releases
 * [OICP 2.3](https://github.com/hubject/oicp/tree/master/OICP-2.3)
 * [OICP 2.2](https://github.com/hubject/oicp/releases/tag/v2.2) - (All new implementations need to be based on OICP 2.3)
-* [OICP 2.1](https://github.com/hubject/oicp/releases/tag/v2.1) - (All new implementations need to be based on OICP 2.3)
 
-> **IMPORTANT**: From July 1st 2021 **OICP 2.1** will not be supported by Hubject 
+Dear users and contributors,
+
+We will be retiring the OICP version 2.1 on 13. April 2023. This decision will allow us to focus on improving and supporting the latest version. Please refer to our documentation for instructions on how to migrate, and we appreciate your continued support.
+
+Thank you,
+Hubject Team
 
 ## License
 [![CC BY-SA 4.0][cc-by-sa-shield]][cc-by-sa]


### PR DESCRIPTION
Please review the removal of the OICP 2.1 https link, as well as public message about the shutdown of OICP 2.1.