### PR TITLE
Update 06_EMP_Code_Snippets.asciidoc

### DIFF
--- a/OICP-2.3/OICP 2.3 EMP/06_EMP_Code_Snippets.asciidoc
+++ b/OICP-2.3/OICP 2.3 EMP/06_EMP_Code_Snippets.asciidoc
@@ -583,7 +583,7 @@ https://www.hubject.com/downloads/
 {
   "CDRForwarded": false,
   "From": "2020-08-23T14:20:10.285Z",
-  "OperatorID": "DE*ABC",
+  "OperatorID": ["DE*ABC"],
   "ProviderID": "DE-DCN",
   "To": "2020-09-23T14:20:10.285Z",
   "SessionID":[


### PR DESCRIPTION
For eRoamingGetChargeDetailRecord the OperatorID in the Request is incorrectly displaying "DE*ABC" in the example.

The display should be: "OperatorID": ["DE*ABC"],