### PR TITLE
Update 02_EMP_Services_and_Operations.asciidoc

### DIFF
--- a/OICP-2.3/OICP 2.3 EMP/02_EMP_Services_and_Operations.asciidoc
+++ b/OICP-2.3/OICP 2.3 EMP/02_EMP_Services_and_Operations.asciidoc
@@ -221,6 +221,8 @@ Identification:<<03_EMP_Data_Types.adoc#IdentificationType,IdentificationType>>:
 PartnerProductID:<<03_EMP_Data_Types.adoc#ProductIDType,ProductIDType>>:A pricing product name (for identifying a tariff) that must be unique:O:
 |========================
 
+Best Practices - The SessionID should not be filled in by the EMP in the initial AuthorizationRemoteStart request. The SessionID is optional for the initial request sent from the EMP message which is e.g. defined as a unique ID from Hubject. The SessionID is then a Mandatory field when the request is sent to the CPO.
+
 [[eRoamingAuthroizeRemoteStop]]
 === eRoamingAuthorizeRemoteStop_V2.1
 


### PR DESCRIPTION
This is a defined issue from several EMP partners that fill in the SessionID initially, but it doesn't make sense to even make it available for the partner to fill in. 

The SessionID is ignored anyway by Hubject, as once a relationship is confirmed internally by Hubject then a SessionID is uniquely created and sent to the CPO.