### PR TITLE
Update 03_EMP_Data_Types.asciidoc

### DIFF
--- a/OICP-2.3/OICP 2.3 EMP/03_EMP_Data_Types.asciidoc
+++ b/OICP-2.3/OICP 2.3 EMP/03_EMP_Data_Types.asciidoc
@@ -944,7 +944,7 @@ Example: *“+0305132787”*
 
 [[UIDType]]
 === UIDType
- ^([0-9A-F]{8,8}|[0-9A-F]{14,14}|[0-9A-F]{20,20})$
+ ^([0-9A-Fa-f]{8,8}|[0-9A-Fa-f]{14,14}|[0-9A-Fa-f]{20,20})$
 
 The expression validates the string as a unique RFID with a length of 8, 14 or 20 characters.
 


### PR DESCRIPTION
The UID Type allows the EMP to send lower case letters resulting in Hubject capitalizing the letters, so the input could be lower or upper case.